### PR TITLE
[CLI] Output deploy addresses

### DIFF
--- a/packages/council-cli/src/commands/deploy/default.ts
+++ b/packages/council-cli/src/commands/deploy/default.ts
@@ -11,7 +11,7 @@ import { requiredRpcUrl, rpcUrlOption } from "src/options/rpc-url";
 import { requiredNumber } from "src/options/utils/requiredNumber";
 import { requiredString } from "src/options/utils/requiredString";
 import { requiredWalletKey, walletKeyOption } from "src/options/wallet-key";
-import { convertBigInts } from "src/utils/bigint/removeBigInts";
+import { stringifyBigInts } from "src/utils/bigint/stringifyBigInts";
 import {
   DAY_IN_BLOCKS,
   DAY_IN_SECONDS,
@@ -710,7 +710,7 @@ export const { command, describe, builder, handler } = createCommandModule({
       chainId: chain.id,
       timestamp: Date.now(),
       deployer: account.address,
-      contracts: convertBigInts(contractInfos),
+      contracts: stringifyBigInts(contractInfos),
     });
 
     // =========================================================================

--- a/packages/council-cli/src/commands/deploy/utils/deploymentStore.ts
+++ b/packages/council-cli/src/commands/deploy/utils/deploymentStore.ts
@@ -1,0 +1,68 @@
+import { JSONStore } from "src/utils/JSONStore";
+
+export const DEFAULT_DEPLOYMENTS_DIR = "./deployments";
+
+export interface ContractInfo {
+  address: string;
+  name: string;
+  deploymentTransactionHash?: string;
+  deploymentArgs?: any[];
+}
+
+export interface DeploymentInfo {
+  name: string;
+  chainId: number;
+  timestamp?: number;
+  deployer?: string;
+  contracts: ContractInfo[];
+}
+
+export function getDeploymentStore(
+  name: string,
+  chainId: number,
+  deploymentsDir = DEFAULT_DEPLOYMENTS_DIR,
+): JSONStore<DeploymentInfo> {
+  return new JSONStore<DeploymentInfo>({
+    path: deploymentsDir,
+    name: `${name}-${chainId}`,
+    defaults: {
+      name,
+      chainId,
+      contracts: [],
+    },
+    schema: {
+      name: {
+        type: "string",
+      },
+      chainId: {
+        type: "number",
+      },
+      timestamp: {
+        type: "number",
+      },
+      deployer: {
+        type: "string",
+      },
+      contracts: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+            },
+            address: {
+              type: "string",
+            },
+            deploymentTransactionHash: {
+              type: "string",
+            },
+            deploymentArgs: {
+              type: "array",
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/packages/council-cli/src/utils/JSONStore.ts
+++ b/packages/council-cli/src/utils/JSONStore.ts
@@ -110,15 +110,24 @@ export class JSONStore<T extends object = Record<string, unknown>> {
   }
 
   /**
-   * Set a key in the store to a given value
-   * @param key - The key to set
-   * @param value - The value to set it to
+   * Set the value for a key or multiple keys in the store
+   * @param key - The key to set or an object of key-value pairs to set
+   * @param value - The value to set the key to if `key` is not an object
    */
-  set<K extends keyof T>(key: K, value: T[K]): void {
-    validateSerializable(key as string, value);
-
+  set(values: Partial<T>): void;
+  set<K extends keyof T>(key: K, value: T[K]): void;
+  set<K extends keyof T>(keyOrValues: K | Partial<T>, value?: T[K]): void {
     const data = this.data;
-    data[key] = value;
+
+    if (typeof keyOrValues !== "object" && value) {
+      validateSerializable(keyOrValues.toString(), value);
+      data[keyOrValues] = value;
+    } else {
+      for (const [key, value] of Object.entries(keyOrValues)) {
+        validateSerializable(key as string, value);
+      }
+      Object.assign(data, keyOrValues);
+    }
 
     this._save(data);
   }
@@ -248,7 +257,7 @@ function removeJSONExtension(filename: string): string {
  */
 function validateSerializable(key: string, value: unknown) {
   const type = typeof value;
-  if (["undefined", "function", "symbol"].includes(typeof value)) {
+  if (["undefined", "function", "symbol", "bigint"].includes(typeof value)) {
     throw new TypeError(
       `Failed to set value of type \`${type}\` for key \`${key}\`. Values must be JSON serializable.`,
     );

--- a/packages/council-cli/src/utils/bigint/removeBigInts.ts
+++ b/packages/council-cli/src/utils/bigint/removeBigInts.ts
@@ -1,0 +1,43 @@
+/**
+ * Get a new type that is the same as `T` but with all bigints converted to
+ * strings
+ */
+export type ConvertedBigInts<T> = T extends bigint
+  ? string
+  : T extends Array<infer U>
+  ? ConvertedBigInts<U>[]
+  : T extends object
+  ? {
+      [K in keyof T]: ConvertedBigInts<T[K]>;
+    }
+  : T;
+
+/**
+ * Convert bigints from an object, array, or primitive to strings
+ * @param obj - The object to convert
+ * @returns The object with bigints converted to strings
+ */
+export function convertBigInts<T>(obj: T): ConvertedBigInts<T> {
+  if (!obj) {
+    return obj as ConvertedBigInts<T>;
+  }
+
+  if (typeof obj === "bigint") {
+    return obj.toString() as ConvertedBigInts<T>;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => convertBigInts(item)) as ConvertedBigInts<T>;
+  }
+
+  if (typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => [
+        key,
+        convertBigInts(value as any),
+      ]),
+    ) as ConvertedBigInts<T>;
+  }
+
+  return obj as ConvertedBigInts<T>;
+}

--- a/packages/council-cli/src/utils/bigint/stringifyBigInts.ts
+++ b/packages/council-cli/src/utils/bigint/stringifyBigInts.ts
@@ -17,7 +17,7 @@ export type ConvertedBigInts<T> = T extends bigint
  * @param obj - The object to convert
  * @returns The object with bigints converted to strings
  */
-export function convertBigInts<T>(obj: T): ConvertedBigInts<T> {
+export function stringifyBigInts<T>(obj: T): ConvertedBigInts<T> {
   if (!obj) {
     return obj as ConvertedBigInts<T>;
   }
@@ -27,14 +27,14 @@ export function convertBigInts<T>(obj: T): ConvertedBigInts<T> {
   }
 
   if (Array.isArray(obj)) {
-    return obj.map((item) => convertBigInts(item)) as ConvertedBigInts<T>;
+    return obj.map((item) => stringifyBigInts(item)) as ConvertedBigInts<T>;
   }
 
   if (typeof obj === "object") {
     return Object.fromEntries(
       Object.entries(obj).map(([key, value]) => [
         key,
-        convertBigInts(value as any),
+        stringifyBigInts(value as any),
       ]),
     ) as ConvertedBigInts<T>;
   }

--- a/packages/council-cli/src/utils/deployContract.ts
+++ b/packages/council-cli/src/utils/deployContract.ts
@@ -58,10 +58,12 @@ export async function deployContract({
   return {
     address: contractAddress,
     hash,
+    deploymentArgs: args,
   };
 }
 
 export type DeployedContract = {
   address: string;
   hash: string;
+  deploymentArgs: any[];
 };


### PR DESCRIPTION
- Added `out-dir` and `name` options to `deploy default`
- Added a function to get a JSON store for deployments
- Added a check for `bigints` in `JSONStore` and a `removeBigInts` util.
- Added an overload signatures to `JSONStore.set` to allow setting multiple keys at once.