### PR TITLE
Add fallback vault UI

### DIFF
--- a/apps/council-ui/pages/vaults/details.tsx
+++ b/apps/council-ui/pages/vaults/details.tsx
@@ -1,9 +1,9 @@
-import assertNever from "assert-never";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
 import { Page } from "src/ui/base/Page";
 import { useChainId } from "src/ui/network/useChainId";
 import { FrozenLockingVaultDetails } from "src/ui/vaults/frozenLockingVault/FrozenLockingVaultDetails";
+import { GenericVaultDetails } from "src/ui/vaults/genericVault/GenericVaultDetails";
 import { GSCVaultDetails } from "src/ui/vaults/gscVault/GSCVaultDetails";
 import { LockingVaultDetails } from "src/ui/vaults/lockingVault/LockingVaultDetails";
 import { VestingVaultDetails } from "src/ui/vaults/vestingVault/VestingVaultDetails";
@@ -39,10 +39,10 @@ export default function Vault(): ReactElement {
             return <VestingVaultDetails address={address as string} />;
 
           case "GSCVault":
-            return <GSCVaultDetails vaultAddress={address as string} />;
+            return <GSCVaultDetails address={address as string} />;
 
           default:
-            assertNever(vaultConfig.type);
+            return <GenericVaultDetails address={address as string} />;
         }
       })()}
     </Page>

--- a/apps/council-ui/pages/vaults/index.tsx
+++ b/apps/council-ui/pages/vaults/index.tsx
@@ -108,7 +108,7 @@ function useVaultsPageData(
 
           return {
             address: vault.address,
-            name: vault.name,
+            name: vaultConfig?.name || vault.name,
             tvp: await vault.getTotalVotingPower?.(),
             votingPower: account && (await vault.getVotingPower(account)),
             sentenceSummary: vaultConfig?.sentenceSummary,

--- a/apps/council-ui/src/clients/council.ts
+++ b/apps/council-ui/src/clients/council.ts
@@ -5,8 +5,8 @@ import {
   LockingVault,
   VestingVault,
   VotingContract,
+  VotingVault,
 } from "@council/sdk";
-import assertNever from "assert-never";
 import { councilConfigs, SupportedChainId } from "src/config/council.config";
 import { provider as getProvider } from "src/provider";
 
@@ -37,7 +37,7 @@ export function getCouncilClient(chainId: SupportedChainId): CouncilClient {
       case "GSCVault":
         return new GSCVault(address, context);
       default:
-        assertNever(type);
+        return new VotingVault(address, context);
     }
   });
 

--- a/apps/council-ui/src/config/CouncilConfig.ts
+++ b/apps/council-ui/src/config/CouncilConfig.ts
@@ -25,7 +25,12 @@ export interface VotingContractConfig extends ContractConfig {
 }
 
 export interface VaultConfig extends ContractConfig {
-  type: "LockingVault" | "FrozenLockingVault" | "VestingVault" | "GSCVault";
+  type:
+    | "LockingVault"
+    | "FrozenLockingVault"
+    | "VestingVault"
+    | "GSCVault"
+    | string;
   name: string;
   /**
    * A short one-liner to show below the vault name.

--- a/apps/council-ui/src/ui/vaults/VaultDetails/VaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/VaultDetails/VaultDetails.tsx
@@ -7,7 +7,7 @@ interface VaultDetailsProps {
   header: ReactNode;
   statsRow: ReactNode;
   paragraphSummary?: string;
-  actions: ReactNode;
+  actions?: ReactNode;
 }
 
 export function VaultDetails({
@@ -26,9 +26,14 @@ export function VaultDetails({
         />
         {header}
       </div>
+
       {statsRow}
+
       {paragraphSummary && <p className="mb-1 text-lg">{paragraphSummary}</p>}
-      <div className="flex flex-col w-full gap-8 sm:flex-row">{actions}</div>
+
+      {actions && (
+        <div className="flex flex-col w-full gap-8 sm:flex-row">{actions}</div>
+      )}
     </>
   );
 }

--- a/apps/council-ui/src/ui/vaults/genericVault/GenericVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/genericVault/GenericVaultDetails.tsx
@@ -1,0 +1,88 @@
+import { VotingVault } from "@council/sdk";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { ReactElement } from "react";
+import { councilConfigs } from "src/config/council.config";
+import { ErrorMessage } from "src/ui/base/error/ErrorMessage";
+import { useCouncil } from "src/ui/council/useCouncil";
+import { useChainId } from "src/ui/network/useChainId";
+
+import { VaultDetails } from "src/ui/vaults/VaultDetails/VaultDetails";
+import { VaultDetailsSkeleton } from "src/ui/vaults/VaultDetails/VaultDetailsSkeleton";
+import { VaultHeader } from "src/ui/vaults/VaultHeader";
+import { useAccount } from "wagmi";
+import { GenericVaultStatsRow } from "./GenericVaultStatsRow";
+
+interface GenericVaultDetailsProps {
+  address: string;
+}
+
+export function GenericVaultDetails({
+  address,
+}: GenericVaultDetailsProps): ReactElement {
+  const { address: account } = useAccount();
+  const { data, status, error } = useGenericVaultDetailsData(address, account);
+
+  if (status === "error") {
+    return <ErrorMessage error={error} />;
+  }
+
+  if (status !== "success") {
+    return <VaultDetailsSkeleton />;
+  }
+
+  return (
+    <VaultDetails
+      name={data.name}
+      paragraphSummary={data.paragraphSummary}
+      header={
+        <VaultHeader name={data.name} descriptionURL={data.descriptionURL} />
+      }
+      statsRow={
+        <GenericVaultStatsRow
+          accountVotingPower={data.accountVotingPower}
+          participants={data.participants}
+        />
+      }
+    />
+  );
+}
+
+interface GenericVaultDetailsData {
+  accountVotingPower: string;
+  descriptionURL: string | undefined;
+  paragraphSummary: string | undefined;
+  name: string | undefined;
+  participants?: number;
+}
+
+function useGenericVaultDetailsData(
+  address: string,
+  account: string | undefined,
+): UseQueryResult<GenericVaultDetailsData> {
+  const { context } = useCouncil();
+  const chainId = useChainId();
+  const coreVotingConfig = councilConfigs[chainId].coreVoting;
+  const vaultConfig = coreVotingConfig.vaults.find(
+    (vault) => vault.address === address,
+  );
+
+  return useQuery({
+    queryKey: ["genericVaultDetails", address, account],
+    queryFn: async () => {
+      const vault = new VotingVault(address, context);
+      const accountVotingPower = account
+        ? await vault.getVotingPower(account)
+        : "0";
+
+      return {
+        accountVotingPower,
+        descriptionURL: vaultConfig?.descriptionURL,
+        paragraphSummary: vaultConfig?.paragraphSummary,
+        name: vaultConfig?.name,
+        participants: vault.getVoters
+          ? (await vault.getVoters()).length
+          : undefined,
+      };
+    },
+  });
+}

--- a/apps/council-ui/src/ui/vaults/genericVault/GenericVaultStatsRow.tsx
+++ b/apps/council-ui/src/ui/vaults/genericVault/GenericVaultStatsRow.tsx
@@ -1,0 +1,42 @@
+import { ReactElement } from "react";
+import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import { Stat } from "src/ui/base/Stat";
+import { DefinitionTooltip } from "src/ui/base/Tooltip/Tooltip";
+import {
+  PARTICIPANTS_TIP,
+  YOUR_VOTING_POWER_TIP,
+} from "src/ui/vaults/tooltips";
+
+interface GeneircVaultStatsRowProps {
+  accountVotingPower: string;
+  participants?: number;
+}
+
+export function GenericVaultStatsRow({
+  accountVotingPower,
+  participants,
+}: GeneircVaultStatsRowProps): ReactElement {
+  return (
+    <div className="flex flex-wrap gap-4">
+      <Stat
+        label={
+          <DefinitionTooltip content={YOUR_VOTING_POWER_TIP}>
+            Your voting power
+          </DefinitionTooltip>
+        }
+        value={+accountVotingPower ? formatBalance(accountVotingPower) : "None"}
+      />
+
+      {typeof participants !== "undefined" && (
+        <Stat
+          label={
+            <DefinitionTooltip content={PARTICIPANTS_TIP}>
+              Participants
+            </DefinitionTooltip>
+          }
+          value={participants}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/council-ui/src/ui/vaults/gscVault/GSCVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/gscVault/GSCVaultDetails.tsx
@@ -21,11 +21,11 @@ import { GSCStatus } from "src/vaults/gscVault/types";
 import { useAccount } from "wagmi";
 
 interface GSCVaultDetailsProps {
-  vaultAddress: string;
+  address: string;
 }
 
 export function GSCVaultDetails({
-  vaultAddress,
+  address: vaultAddress,
 }: GSCVaultDetailsProps): ReactElement {
   const { address: account } = useAccount();
   const { data, status, error } = useGSCVaultDetails({

--- a/apps/council-ui/src/ui/vaults/hooks/useDelegatesByVault.ts
+++ b/apps/council-ui/src/ui/vaults/hooks/useDelegatesByVault.ts
@@ -1,6 +1,5 @@
 import { LockingVault, VestingVault, Voter } from "@council/sdk";
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import assertNever from "assert-never";
 import { useCouncil } from "src/ui/council/useCouncil";
 import { useChainId } from "src/ui/network/useChainId";
 import { getVaultConfig } from "src/vaults/vaults";
@@ -40,10 +39,8 @@ export function useDelegatesByVault(): UseQueryResult<Record<string, Voter>> {
                 typedDelegationVault = vault as VestingVault;
                 break;
               case "GSCVault":
-                // GSCVault does not have delegation, do nothing
-                break;
+              // GSCVault does not have delegation, do nothing
               default:
-                assertNever(config.type);
             }
 
             if (typedDelegationVault) {


### PR DESCRIPTION
All of the teams starting to adopt Council are using custom vaults and cannot use the UI in it's current state since the vaults have to be a known type. This PR adds a fallback UI for unknown vault types.