### PR TITLE
[CLI] Add missing deploy args

### DIFF
--- a/packages/council-cli/src/commands/deploy/airdrop.ts
+++ b/packages/council-cli/src/commands/deploy/airdrop.ts
@@ -34,6 +34,12 @@ export const { command, aliases, describe, builder, handler } =
           describe: "The address of the ERC20 token contract",
           type: "string",
         },
+        v: {
+          alias: ["locking-vault", "lockingVault"],
+          describe:
+            "The address of the locking vault contract that will be used when calling OptimisticRewards.claimAndDelegate()",
+          type: "string",
+        },
         e: {
           alias: ["expiration"],
           describe:
@@ -62,6 +68,11 @@ export const { command, aliases, describe, builder, handler } =
         message: "Enter token address",
       });
 
+      const lockingVault = await requiredString(args.lockingVault, {
+        name: "lockingVault",
+        message: "Enter locking vault address",
+      });
+
       const expiration = await requiredNumber(args.expiration, {
         name: "expiration",
         message: "Enter expiration timestamp (in seconds)",
@@ -79,6 +90,7 @@ export const { command, aliases, describe, builder, handler } =
         merkleRoot: root,
         token,
         expiration,
+        lockingVault,
         account,
         rpcUrl,
         chain,
@@ -96,6 +108,7 @@ export interface DeployAirDropOptions {
   merkleRoot: string;
   token: string;
   expiration: number;
+  lockingVault: string;
   account: PrivateKeyAccount;
   rpcUrl: string;
   chain: Chain;
@@ -107,6 +120,7 @@ export async function deployAirDrop({
   merkleRoot,
   token,
   expiration,
+  lockingVault,
   account,
   rpcUrl,
   chain,
@@ -114,7 +128,7 @@ export async function deployAirDrop({
 }: DeployAirDropOptions): Promise<DeployedContract> {
   return deployContract({
     abi: Airdrop__factory.abi,
-    args: [owner, merkleRoot, token, expiration],
+    args: [owner, merkleRoot, token, expiration, lockingVault],
     bytecode: Airdrop__factory.bytecode,
     account,
     rpcUrl,

--- a/packages/council-cli/src/commands/deploy/optimistic-rewards.ts
+++ b/packages/council-cli/src/commands/deploy/optimistic-rewards.ts
@@ -43,6 +43,12 @@ export const { command, aliases, describe, builder, handler } =
           describe: "The address of the ERC20 token to distribute",
           type: "string",
         },
+        v: {
+          alias: ["locking-vault", "lockingVault"],
+          describe:
+            "The address of the locking vault contract that will be used when calling Airdrop.claimAndDelegate()",
+          type: "string",
+        },
         n: chainOption,
         u: rpcUrlOption,
         w: walletKeyOption,
@@ -75,6 +81,11 @@ export const { command, aliases, describe, builder, handler } =
         message: "Enter token address",
       });
 
+      const lockingVault = await requiredString(args.lockingVault, {
+        name: "lockingVault",
+        message: "Enter locking vault address",
+      });
+
       const chain = await requiredChain(args.chain);
       const rpcUrl = await requiredRpcUrl(args.rpcUrl);
       const walletKey = await requiredWalletKey(args.walletKey);
@@ -88,6 +99,7 @@ export const { command, aliases, describe, builder, handler } =
         proposer,
         revoker,
         token,
+        lockingVault,
         account,
         rpcUrl,
         chain,
@@ -108,6 +120,7 @@ export interface DeployOptimisticRewardsOptions {
   proposer: string;
   revoker: string;
   token: string;
+  lockingVault: string;
   account: PrivateKeyAccount;
   rpcUrl: string;
   chain: Chain;
@@ -120,6 +133,7 @@ export async function deployOptimisticRewards({
   proposer,
   revoker,
   token,
+  lockingVault,
   account,
   rpcUrl,
   chain,
@@ -127,7 +141,7 @@ export async function deployOptimisticRewards({
 }: DeployOptimisticRewardsOptions): Promise<DeployedContract> {
   return deployContract({
     abi: OptimisticRewards__factory.abi,
-    args: [owner, startingRoot, proposer, revoker, token],
+    args: [owner, startingRoot, proposer, revoker, token, lockingVault],
     bytecode: OptimisticRewards__factory.bytecode,
     account,
     rpcUrl,


### PR DESCRIPTION
Airdrop and OptimisticRewards deploy commands were missing the LockingVault argument.