### PR TITLE
[CLI] Add MockToken commands

### DIFF
--- a/packages/council-cli/src/commands/mock-token.ts
+++ b/packages/council-cli/src/commands/mock-token.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+import { createCommandModule } from "src/utils/createCommandModule";
+import {
+  COMMAND_FILE_EXTENSIONS,
+  selectCommandHandler,
+} from "src/utils/selectCommandHandler";
+
+const commandDir = "./mock-token";
+
+export const { command, describe, builder, handler } = createCommandModule({
+  command: "mock-token [command]",
+  describe: "Interact with a LockingVault contract",
+
+  builder: (yargs) => {
+    return yargs.commandDir(commandDir, {
+      extensions: COMMAND_FILE_EXTENSIONS,
+    });
+  },
+
+  handler: selectCommandHandler({
+    commandsPath: path.resolve(__dirname, commandDir),
+  }),
+});

--- a/packages/council-cli/src/commands/mock-token/mint.ts
+++ b/packages/council-cli/src/commands/mock-token/mint.ts
@@ -1,0 +1,63 @@
+import { CouncilContext, MockToken } from "@council/sdk";
+import { getDefaultProvider, Wallet } from "ethers";
+import signale from "signale";
+import { requiredRpcUrl, rpcUrlOption } from "src/options/rpc-url";
+import { requiredNumberString } from "src/options/utils/requiredNumberString";
+import { requiredString } from "src/options/utils/requiredString";
+import { requiredWalletKey, walletKeyOption } from "src/options/wallet-key";
+import { createCommandModule } from "src/utils/createCommandModule";
+
+export const { command, describe, builder, handler } = createCommandModule({
+  command: "mint [OPTIONS]",
+  describe: "Mint tokens",
+
+  builder: (yargs) => {
+    return yargs.options({
+      a: {
+        alias: ["address"],
+        describe: "The token contract address",
+        type: "string",
+      },
+      f: {
+        alias: ["account"],
+        describe: "The account to mint tokens for",
+        type: "string",
+      },
+      t: {
+        alias: ["amount"],
+        describe: "The amount of tokens to mint",
+        type: "string",
+      },
+      w: walletKeyOption,
+      r: rpcUrlOption,
+    });
+  },
+
+  handler: async (args) => {
+    const address = await requiredString(args.address, {
+      name: "address",
+      message: "Enter token contract address",
+    });
+
+    const account = await requiredString(args.account, {
+      name: "account",
+      message: "Enter account to mint tokens for",
+    });
+
+    const amount = await requiredNumberString(args.amount, {
+      name: "amount",
+      message: "Enter amount of tokens to mint",
+    });
+
+    const walletKey = await requiredWalletKey(args.walletKey);
+    const rpcURL = await requiredRpcUrl(args.rpcUrl);
+
+    const provider = getDefaultProvider(rpcURL);
+    const context = new CouncilContext(provider);
+    const token = new MockToken(address, context);
+
+    const signer = new Wallet(walletKey, provider);
+
+    signale.success(await token.mint(signer, account, amount));
+  },
+});

--- a/packages/council-cli/src/commands/mock-token/set-allowance.ts
+++ b/packages/council-cli/src/commands/mock-token/set-allowance.ts
@@ -1,0 +1,76 @@
+import { CouncilContext, MockToken } from "@council/sdk";
+import { getDefaultProvider, Wallet } from "ethers";
+import signale from "signale";
+import { requiredRpcUrl, rpcUrlOption } from "src/options/rpc-url";
+import { requiredNumberString } from "src/options/utils/requiredNumberString";
+import { requiredString } from "src/options/utils/requiredString";
+import { requiredWalletKey, walletKeyOption } from "src/options/wallet-key";
+import { createCommandModule } from "src/utils/createCommandModule";
+
+export const { command, describe, builder, handler } = createCommandModule({
+  command: "set-allowance [OPTIONS]",
+  aliases: ["setAllowance"],
+  describe: "Set an account's token allowance",
+
+  builder: (yargs) => {
+    return yargs.options({
+      a: {
+        alias: ["address"],
+        describe: "The token contract address",
+        type: "string",
+      },
+      o: {
+        alias: ["owner"],
+        describe: "The address of the token owner",
+        type: "string",
+      },
+      s: {
+        alias: ["spender"],
+        describe: "The address of the token spender",
+        type: "string",
+      },
+      b: {
+        alias: ["balance"],
+        describe:
+          "The amount of tokens the spender is allowed to spend from the owner's account",
+        type: "string",
+      },
+      w: walletKeyOption,
+      r: rpcUrlOption,
+    });
+  },
+
+  handler: async (args) => {
+    const address = await requiredString(args.address, {
+      name: "address",
+      message: "Enter token contract address",
+    });
+
+    const owner = await requiredString(args.owner, {
+      name: "owner",
+      message: "Enter the token owner's address",
+    });
+
+    const spender = await requiredString(args.spender, {
+      name: "spender",
+      message: "Enter the token spender's address",
+    });
+
+    const amount = await requiredNumberString(args.balance, {
+      name: "amount",
+      message:
+        "Enter amount of tokens the spender is allowed to spend from the owner's account",
+    });
+
+    const walletKey = await requiredWalletKey(args.walletKey);
+    const rpcURL = await requiredRpcUrl(args.rpcUrl);
+
+    const provider = getDefaultProvider(rpcURL);
+    const context = new CouncilContext(provider);
+    const token = new MockToken(address, context);
+
+    const signer = new Wallet(walletKey, provider);
+
+    signale.success(await token.setAllowance(signer, owner, spender, amount));
+  },
+});

--- a/packages/council-cli/src/commands/mock-token/set-balance.ts
+++ b/packages/council-cli/src/commands/mock-token/set-balance.ts
@@ -1,0 +1,64 @@
+import { CouncilContext, MockToken } from "@council/sdk";
+import { getDefaultProvider, Wallet } from "ethers";
+import signale from "signale";
+import { requiredRpcUrl, rpcUrlOption } from "src/options/rpc-url";
+import { requiredNumberString } from "src/options/utils/requiredNumberString";
+import { requiredString } from "src/options/utils/requiredString";
+import { requiredWalletKey, walletKeyOption } from "src/options/wallet-key";
+import { createCommandModule } from "src/utils/createCommandModule";
+
+export const { command, describe, builder, handler } = createCommandModule({
+  command: "set-balance [OPTIONS]",
+  aliases: ["setBalance"],
+  describe: "Set an account's token balance",
+
+  builder: (yargs) => {
+    return yargs.options({
+      a: {
+        alias: ["address"],
+        describe: "The token contract address",
+        type: "string",
+      },
+      f: {
+        alias: ["account"],
+        describe: "The account to set balance for",
+        type: "string",
+      },
+      b: {
+        alias: ["balance"],
+        describe: "The new balance (as a decimal string) for the account",
+        type: "string",
+      },
+      w: walletKeyOption,
+      r: rpcUrlOption,
+    });
+  },
+
+  handler: async (args) => {
+    const address = await requiredString(args.address, {
+      name: "address",
+      message: "Enter token contract address",
+    });
+
+    const account = await requiredString(args.account, {
+      name: "account",
+      message: "Enter account to set balance for",
+    });
+
+    const balance = await requiredNumberString(args.balance, {
+      name: "balance",
+      message: "Enter new balance for account",
+    });
+
+    const walletKey = await requiredWalletKey(args.walletKey);
+    const rpcURL = await requiredRpcUrl(args.rpcUrl);
+
+    const provider = getDefaultProvider(rpcURL);
+    const context = new CouncilContext(provider);
+    const token = new MockToken(address, context);
+
+    const signer = new Wallet(walletKey, provider);
+
+    signale.success(await token.setBalance(signer, account, balance));
+  },
+});

--- a/packages/council-cli/src/commands/server.ts
+++ b/packages/council-cli/src/commands/server.ts
@@ -60,7 +60,7 @@ export const { command, describe, builder, handler } = createCommandModule({
     const server = ganache.server({
       blockTime: args.blockTime,
       chain: {
-        chainId: args.chainId,
+        chainId: args.chainId || 31337,
       },
 
       wallet: {

--- a/packages/council-cli/src/utils/chains.ts
+++ b/packages/council-cli/src/utils/chains.ts
@@ -1,7 +1,7 @@
 import {
   arbitrum,
   goerli,
-  localhost,
+  hardhat,
   mainnet,
   optimism,
   polygon,
@@ -9,7 +9,7 @@ import {
 } from "viem/chains";
 
 export const supportedChains = {
-  localhost,
+  localhost: hardhat,
   mainnet,
   goerli,
   sepolia,


### PR DESCRIPTION
Added a `mint`, `set-allowance`, and `set-balance` commands for the `MockERC20` contract.

<img width="587" alt="image" src="https://github.com/delvtech/council-kit/assets/3289505/ecf3774e-262a-452f-97c3-c7195e7aed54">

<img width="627" alt="image" src="https://github.com/delvtech/council-kit/assets/3289505/495e1534-bcb4-46b2-8267-aea54552603d">

<img width="624" alt="image" src="https://github.com/delvtech/council-kit/assets/3289505/2598a9dc-8cb8-4239-b4ac-3b74019be4ed">

<img width="627" alt="image" src="https://github.com/delvtech/council-kit/assets/3289505/21829873-602e-4414-ab04-4906cb2d7f57">
