### PR TITLE
Add missing `publishConfig` setting to artifacts package.json

### DIFF
--- a/.changeset/brown-parrots-greet.md
+++ b/.changeset/brown-parrots-greet.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/council-artifacts": patch
+---
+
+Add missing publishConfig setting in package.json

--- a/packages/council-artifacts/package.json
+++ b/packages/council-artifacts/package.json
@@ -27,5 +27,8 @@
     "@council/tsconfig": "*",
     "hardhat": "^2.20.1",
     "typescript": "^5.3.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
The last release was borked because the artifacts package was missing the `publishConfig` setting.