### PR TITLE
[CLI] Add hardhat to peer deps and handle errors

### DIFF
--- a/.changeset/polite-students-dance.md
+++ b/.changeset/polite-students-dance.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/council-cli": patch
+---
+
+Make Hardhat a peer dependency and add more error handling

--- a/.changeset/soft-steaks-hunt.md
+++ b/.changeset/soft-steaks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/council-artifacts": patch
+---
+
+Remove hardhat dependency

--- a/packages/council-artifacts/package.json
+++ b/packages/council-artifacts/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@council/eslint-config": "*",
     "@council/tsconfig": "*",
-    "hardhat": "^2.20.1",
     "typescript": "^5.3.3"
   },
   "publishConfig": {

--- a/packages/council-cli/package.json
+++ b/packages/council-cli/package.json
@@ -15,6 +15,15 @@
     "build": "rimraf dist && tsc",
     "watch": "tsc --watch"
   },
+  "peerDependencies": {
+    "viem": ">=2",
+    "hardhat": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "hardhat": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@delvtech/council-artifacts": "^0.0.2",
     "@delvtech/council-viem": "^0.0.2",
@@ -43,9 +52,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "viem": "^2.7.12"
-  },
-  "peerDependencies": {
-    "viem": ">=2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/council-cli/package.json
+++ b/packages/council-cli/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/council.js",
-  "bin": "dist/council.js",
+  "bin": {
+    "council": "dist/council.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/council-cli/src/commands/server.ts
+++ b/packages/council-cli/src/commands/server.ts
@@ -1,6 +1,16 @@
 import { command } from "clide-js";
-import hre from "hardhat";
+import { execSync } from "node:child_process";
+import signale from "signale";
 import { parseUnits } from "viem";
+
+// This command is only available if the optional hardhat peer dependency is
+// installed so we import it dynamically to avoid crashing if it's not
+// installed.
+let error: Error | undefined;
+const hardhat = await import("hardhat").catch((e) => {
+  error = e;
+  return undefined;
+});
 
 export default command({
   description: "Start a local ethereum node",
@@ -34,6 +44,34 @@ export default command({
   },
 
   handler: async ({ options, end }) => {
+    if (!hardhat) {
+      // https://hardhat.org/hardhat-runner/docs/errors#HH1
+      if (error?.message.startsWith("HH1")) {
+        signale.error(
+          "Must be inside a Hardhat project with a hardhat config file.",
+        );
+      } else if (error?.message.startsWith("HH")) {
+        signale.error(error.message);
+      } else {
+        const globalNodeModules = execSync("npm root -g").toString().trim();
+        const localNodeModules = execSync("npm root").toString().trim();
+        const isGlobal = globalNodeModules === localNodeModules;
+
+        signale.error(error?.message ?? error);
+        signale.error(
+          `This command requires hardhat to be installed. Run ${
+            isGlobal
+              ? "`npm install -g hardhat`"
+              : "`npm install --save-dev hardhat`"
+          } to install hardhat.`,
+        );
+      }
+
+      return end();
+    }
+
+    const hre = hardhat.default;
+
     const host = await options.host();
     const port = await options.port();
     const balance = await options.balance();

--- a/packages/council-cli/src/council.ts
+++ b/packages/council-cli/src/council.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { help, run } from "clide-js";
 import { commandMenu } from "clide-plugin-command-menu";
+import signale from "signale";
 
 run({
   plugins: [
@@ -34,4 +35,6 @@ run({
       }
     }
   },
+}).catch((error) => {
+  signale.error(error);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,10 +4117,25 @@ check-error@^1.0.3:
   dependencies:
     get-func-name "^2.0.2"
 
-chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.1, chokidar@^3.5.2, chokidar@^3.5.3:
+chokidar@3.5.3, chokidar@^3.5.1, chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -6003,6 +6018,17 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 glob@^7.1.3, glob@^7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -7613,6 +7639,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist-options@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -7662,9 +7695,9 @@ mnemonist@^0.38.0:
     obliterator "^2.0.0"
 
 mocha@^10.0.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -7673,13 +7706,12 @@ mocha@^10.0.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.2.0"
+    glob "8.1.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -7750,11 +7782,6 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 nanoid@^3.3.4, nanoid@^3.3.7:
   version "3.3.7"
@@ -10377,9 +10404,9 @@ undici-types@~5.26.4:
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici@^5.14.0:
-  version "5.28.2"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.2.tgz#fea200eac65fc7ecaff80a023d1a0543423b4c91"
-  integrity sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==
+  version "5.28.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
+  integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 


### PR DESCRIPTION
The `server` command requires hardhat to be installed and to be run inside a hardhat project. This PR makes hardhat an optional peer dependency and adds graceful error handling.