### PR TITLE
Fix delegation

### DIFF
--- a/apps/council-ui/src/ui/vaults/ChangeDelegateForm.tsx
+++ b/apps/council-ui/src/ui/vaults/ChangeDelegateForm.tsx
@@ -5,6 +5,7 @@ import { useDisplayName } from "src/ui/base/formatting/useDisplayName";
 import { Input } from "src/ui/base/forms/Input";
 import { VoterAddress } from "src/ui/voters/VoterAddress";
 import { zeroAddress } from "viem";
+import { normalize } from "viem/ens";
 import { useEnsResolver } from "wagmi";
 
 interface ChangeDelegateFormProps {
@@ -24,10 +25,15 @@ export function ChangeDelegateForm({
   const isDelegateZeroAddress = currentDelegate === zeroAddress;
 
   const [newDelegate, setNewDelegate] = useState<string>("");
-  const { data: newDelegateAddress } = useEnsResolver({
-    name: newDelegate,
+  const { data: resolvedEnsAddress } = useEnsResolver({
+    name: normalize(newDelegate),
   });
   const isNotNew = newDelegate === currentDelegate;
+
+  const newDelegateAddress =
+    resolvedEnsAddress && resolvedEnsAddress !== zeroAddress
+      ? resolvedEnsAddress
+      : (newDelegate as `0x${string}`);
 
   return (
     <div className="daisy-card flex h-fit basis-1/2 flex-col gap-y-4 bg-base-200 p-4">

--- a/packages/council-cli/package.json
+++ b/packages/council-cli/package.json
@@ -32,7 +32,7 @@
     "ajv": "^8.12.0",
     "cfonts": "^3.2.0",
     "cli-table": "^0.3.11",
-    "clide-js": "^0.1.3",
+    "clide-js": "^0.1.5",
     "clide-plugin-command-menu": "^0.0.7",
     "colors": "^1.4.0",
     "dotenv": "^16.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,10 +4217,10 @@ cli-truncate@^4.0.0:
     slice-ansi "^5.0.0"
     string-width "^7.0.0"
 
-clide-js@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/clide-js/-/clide-js-0.1.3.tgz#6f500578d453714c8e51f32acd59ddc743e5e3c0"
-  integrity sha512-D8qIBdg4ZwD+zsoliDc079h1Dm0hIf1219jppPZeINmG/qIoi5CZCJVA7ToHIf74h4oVON5IEObszFd0pG5XPg==
+clide-js@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/clide-js/-/clide-js-0.1.5.tgz#e884b6536e5972969f1ddd2d0fb0b21ab47856ee"
+  integrity sha512-BP//lZ6kSHNfRkPKP5rN+qfy6GP3acYbWV8JJYXXgjENKGnIyvYy3COZn47Gqm7TchRWCilA9Ph7tTG1x6fJ+w==
   dependencies:
     cliui "^8.0.1"
     prompts "^2.4.2"


### PR DESCRIPTION
In a recent upgrade (#407) the change delegation form was refactored to use the [`useEnsResolver` wagmi hook](https://wagmi.sh/react/api/hooks/useEnsResolver), which returns the zero address for names that don't resolve. This PR refactors the form to use the entered address directly when the hook returns the zero address.