### PR TITLE
Fix WalletConnect

### DIFF
--- a/apps/council-ui/src/lib/rainbowKit.ts
+++ b/apps/council-ui/src/lib/rainbowKit.ts
@@ -8,13 +8,13 @@ import {
 } from "@rainbow-me/rainbowkit/wallets";
 import { chains, transports } from "src/lib/wagmi";
 
-const { NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID, NODE_ENV } = process.env;
+const walletConnectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID;
 const wallets = [injectedWallet, safeWallet, rainbowWallet, metaMaskWallet];
 
 // WalletConnect
-if (NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID) {
+if (walletConnectId) {
   wallets.push(walletConnectWallet);
-} else if (NODE_ENV === "development") {
+} else if (process.env.NODE_ENV === "development") {
   console.warn(
     "Missing WalletConnect project ID. Set the NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID variable in your environment to use WalletConnect.",
   );
@@ -22,7 +22,7 @@ if (NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID) {
 
 export const wagmiConfig = getDefaultConfig({
   appName: "Council",
-  projectId: NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || "0",
+  projectId: walletConnectId || "0",
   chains: chains as any,
   transports,
   wallets: [


### PR DESCRIPTION
Destructuring assignment of environment variables doesn't work so the WalletConnect environment variable was undefined. This fixes the check to ensure WalletConnect is visible when the environment variable is defined.